### PR TITLE
Reduce binary size for release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ path = "src/main.rs"
 [lib]
 name = "dogwatch"
 path = "src/lib.rs"
+
+[profile.release]
+strip = true
+lto = true


### PR DESCRIPTION
Hi! Really nice project!

I added 2 lines to reduce the binary size for release. With this it goes from 4.7mb to 840kb.

Source: https://github.com/johnthagen/min-sized-rust